### PR TITLE
Potential fix for code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.component.ts
+++ b/src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.component.ts
@@ -17,7 +17,7 @@ export default class PasswordStrengthBarComponent {
 
   measureStrength(p: string): number {
     let force = 0;
-    const regex = /[$-/:-?{-~!"^_`[\]]/g; // "
+    const regex = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g; // "
     const lowerLetters = /[a-z]+/.test(p);
     const upperLetters = /[A-Z]+/.test(p);
     const numbers = /\d+/.test(p);


### PR DESCRIPTION
Potential fix for [https://github.com/EricSherrill/jhipster-sample-application/security/code-scanning/1](https://github.com/EricSherrill/jhipster-sample-application/security/code-scanning/1)

In general, the fix is to avoid ambiguous range expressions like `$-/` inside a character class and instead list the exact characters you want to match, escaping any that are special (`-`, `]`, `\`) or that CodeQL flags as suspicious ranges. This makes the intent of the regex clear and prevents unintended extra characters from being included.

For this specific case in `src/main/webapp/app/account/password/password-strength-bar/password-strength-bar.component.ts`, line 20 defines:

```ts
const regex = /[$-/:-?{-~!"^_`[\]]/g;
```

The intent is clearly to detect “symbol” characters (non-alphanumeric ASCII punctuation). We can preserve the behavior while removing ambiguous ranges by enumerating the punctuation characters explicitly. One straightforward fix is to replace the current pattern with a safer, clearer symbol class such as:

```ts
const regex = /[!-/:-@[-`{-~]/g;
```

This uses known-safe ranges (`!-/`, `:-@`, `[-` and `{-~`) that do not create the flagged `$-/` range and are commonly used to cover ASCII punctuation, or, if we want to be more explicit and avoid ranges entirely, we can list characters out:

```ts
const regex = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g;
```

The second form is completely explicit and eliminates any suspicious or confusing ranges. It continues to capture the same kinds of password symbols used in strength calculations and only affects the `symbols` boolean in `measureStrength`, leaving the rest of the logic intact. No new imports or dependencies are needed; we only change the regex literal on line 20.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
