### PR TITLE
Potential fix for code scanning alert no. 2: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/mycompany/myapp/config/SecurityConfiguration.java
+++ b/src/main/java/com/mycompany/myapp/config/SecurityConfiguration.java
@@ -48,7 +48,6 @@ public class SecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
         http
             .cors(withDefaults())
-            .csrf(csrf -> csrf.disable())
             .addFilterAfter(new SpaWebFilter(), BasicAuthenticationFilter.class)
             .headers(headers ->
                 headers


### PR DESCRIPTION
Potential fix for [https://github.com/EricSherrill/jhipster-sample-application/security/code-scanning/2](https://github.com/EricSherrill/jhipster-sample-application/security/code-scanning/2)

In general, the fix is to stop globally disabling CSRF protection and instead either (a) leave Spring Security’s default CSRF configuration enabled, or (b) enable it with explicit ignoring rules only for endpoints that truly never process browser‑initiated state‑changing requests (for example, pure token introspection endpoints or certain machine‑to‑machine APIs).

In this specific file, the single best change with minimal impact is to remove the `.csrf(csrf -> csrf.disable())` call so that the default CSRF protection is restored. This restores standard Spring behaviour without altering any authorization rules, filters, or headers already configured. If necessary, further fine‑tuning (e.g., configuring a `CookieCsrfTokenRepository` for a SPA) can be done elsewhere, but that is outside the scope of the CodeQL finding and cannot be safely inferred from the snippet.

Concretely:
- Edit `src/main/java/com/mycompany/myapp/config/SecurityConfiguration.java`.
- In the `filterChain` method, remove the `.csrf(csrf -> csrf.disable())` line (line 51).
- Keep the rest of the fluent configuration as it is.

No additional methods or imports are required for this minimal fix; Spring’s default CSRF behaviour will apply automatically.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
